### PR TITLE
fix: improve devcontainer volume mounts for persistence

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,10 +13,11 @@
 	},
 	"onCreateCommand": "/bin/bash .devcontainer/on-create.sh",
 	"mounts": [
-		"source=${localWorkspaceFolderBasename}-claude,target=/home/vscode/.local/share/claude,type=volume"
+		"source=${localWorkspaceFolderBasename}-claude,target=/home/vscode/.claude,type=volume",
+		"source=${localWorkspaceFolderBasename}-pnpm,target=/home/vscode/.pnpm,type=volume"
 	],
 	"remoteEnv": {
-		"CLAUDE_CONFIG_DIR": "/home/vscode/.local/share/claude"
+		"CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
 	},
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -eu
 
-sudo mkdir -p /home/vscode/.claude
-sudo chown -R vscode /home/vscode/.claude
+mkdir -p /home/vscode/.claude
+chown -R vscode /home/vscode/.claude
+
+mkdir -p /home/vscode/.pnpm
+chown -R vscode /home/vscode/.pnpm

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -eu
 
-sudo mkdir -p /home/vscode/.local/share/claude
-sudo chown -R vscode /home/vscode/.local/share/claude
+sudo mkdir -p /home/vscode/.claude
+sudo chown -R vscode /home/vscode/.claude

--- a/docs/dev-sessions/20250614225623-devcontainer-volume-mounts-fix.md
+++ b/docs/dev-sessions/20250614225623-devcontainer-volume-mounts-fix.md
@@ -43,12 +43,29 @@ devcontainerのpnpmとClaude Code関連フォルダのマウントが正しく�
 - `.devcontainer/on-create.sh`: 新しいClaude設定ディレクトリに対応
 - `docs/dev-sessions/20250614225623-devcontainer-volume-mounts-fix.md`: セッション記録
 
+### 5. Copilotフィードバック対応
+**User**: プルリクエストにコメントがついてます。確認してもらえますか
+
+**Claude**: GitHub Copilotから2つの改善提案を確認：
+1. `on-create.sh`で`sudo`が不要（rootで実行されるため）
+2. pnpmディレクトリの初期化が不足
+
+**User**: 一旦修正してみてください。コミットする前に、このリポジトリでテストするので止めてください。
+
+**Claude**: Copilotの提案に従い`on-create.sh`を修正。`sudo`削除とpnpmディレクトリ初期化を追加。
+
+**User**: 確認しました。正しく動作するようなので続きをお願いします
+
+**Claude**: テスト完了確認後、修正をコミットしてプルリクエストを更新。
+
 ## 次のステップ
-- プルリクエスト #2 のレビューと対応
-- devcontainer再構築でのテスト確認
-- GitHub CLI認証済み環境でのワークフロー活用
+- プルリクエスト #2 のマージ準備完了
+- devcontainer設定の本格運用開始
+- GitHub CLI + Copilotレビューワークフローの活用
 
 ## 技術メモ
 - GitHub CLI認証フローが確立された
+- GitHub Copilotの自動レビュー機能が有効活用された
 - devcontainerのボリュームマウント戦略が改善された
 - pnpmキャッシュ永続化によりコンテナ再構築の高速化が期待される
+- rootで実行されるスクリプトでの`sudo`不要の学習

--- a/docs/dev-sessions/20250614225623-devcontainer-volume-mounts-fix.md
+++ b/docs/dev-sessions/20250614225623-devcontainer-volume-mounts-fix.md
@@ -1,0 +1,54 @@
+# 開発セッション: devcontainer volume mounts修正
+
+**日時**: 2025-06-14
+**時間**: 22:56:23 (JST)
+**参加者**: User, Claude Code
+
+## 概要
+devcontainerのpnpmとClaude Code関連フォルダのマウントが正しく動作するように修正し、プルリクエストを作成した。
+
+## 重要な決定事項
+- Claude Code設定パスを`~/.local/share/claude`から`~/.claude`に変更
+- pnpmキャッシュ永続化のため`~/.pnpm`ボリュームマウントを追加
+- GitHub CLIを使用してプルリクエスト作成フローを確立
+
+## 会話の流れ
+
+### 1. プルリクエスト作成依頼
+**User**: pnpmとclaude-code関連のフォルダのマウントが正しく動作するように修正しました。差分を確認してプルリクエストを作成してください
+
+**Claude**: git status、git diff、git logで現在の変更内容を確認。devcontainer.jsonとon-create.shに変更があることを確認。
+
+### 2. ブランチ作成とコミット
+**User**: [変更内容確認]
+
+**Claude**: fix/devcontainer-volume-mountsブランチを作成し、変更をコミット。適切なコミットメッセージでConventional Commits形式を使用。
+
+### 3. GitHub CLI認証問題
+**User**: チャットでは日本語で話すようにしてください。すでにテストは完了しているのでテストのチェックリストは不要です
+
+**Claude**: 日本語対応とテストチェックリスト除去。GitHub CLIが未インストールのためWebインターフェースURLを提供。
+
+### 4. GitHub CLI導入とプルリクエスト作成
+**User**: GitHub CLIを導入したのでリトライしてください
+
+**Claude**: GitHub CLI認証が必要であることを確認し、認証手順を案内。
+
+**User**: 認証しました
+
+**Claude**: プルリクエスト #2 を正常に作成完了。
+
+## 作成・変更されたファイル
+- `.devcontainer/devcontainer.json`: Claude設定パス変更、pnpmボリュームマウント追加
+- `.devcontainer/on-create.sh`: 新しいClaude設定ディレクトリに対応
+- `docs/dev-sessions/20250614225623-devcontainer-volume-mounts-fix.md`: セッション記録
+
+## 次のステップ
+- プルリクエスト #2 のレビューと対応
+- devcontainer再構築でのテスト確認
+- GitHub CLI認証済み環境でのワークフロー活用
+
+## 技術メモ
+- GitHub CLI認証フローが確立された
+- devcontainerのボリュームマウント戦略が改善された
+- pnpmキャッシュ永続化によりコンテナ再構築の高速化が期待される


### PR DESCRIPTION
## Summary
- Fixed Claude Code config directory path for better compatibility
- Added pnpm volume mount to persist package manager cache
- Updated directory ownership and permissions handling

## Changes Made
- **Claude Config Path**: Changed from `~/.local/share/claude` to `~/.claude` for simpler path and better compatibility
- **pnpm Cache Persistence**: Added volume mount for `~/.pnpm` to persist package manager cache across container rebuilds
- **Directory Setup**: Updated `on-create.sh` to properly initialize the new Claude config directory

## Benefits
- Faster container rebuilds with persistent pnpm cache
- Improved Claude Code configuration persistence
- Cleaner directory structure

🤖 Generated with [Claude Code](https://claude.ai/code)